### PR TITLE
doc/osc_api.md: initial writeup of basic OSC API

### DIFF
--- a/doc/osc_api.md
+++ b/doc/osc_api.md
@@ -56,3 +56,25 @@ Exception Buttons
 There are a few buttons that are only ever a specifc colour:
 * Play button *always* green
 * Rec button *always* red
+
+Pads
+----
+The OSC API also allows control over the pad colours. Changing the pad
+colours is achieved by sending 3 parameters to maschine.rs:
+* Pad number
+* Colour code (see above)
+* Brightness (see above)
+
+Pads start counting from the top left, top row, 2nd from left is #1, and
+so on. Some examples follow:
+
+```
+# top left to green, full brightness:
+oscsend localhost 42434 /maschine/pad iif 0 16384 1.0
+
+# low-mid right to blue, full:
+oscsend localhost 42434 /maschine/pad iif 11 256 1.0
+
+# bottom-mid right to red, half:
+oscsend localhost 42434 /maschine/pad iif 13 256 1.0
+```

--- a/doc/osc_api.md
+++ b/doc/osc_api.md
@@ -1,0 +1,58 @@
+Maschine.rs OSC API
+===================
+This document describes the OSC API that maschine.rs exposes. It is written
+in the hope that anybody implementing integration with the maschine
+hardware can do so quickly and easily.
+
+Some devices in the Maschine family have more buttons and capabilities,
+these are presented in sub-sections for each device.
+
+For testing OSC commands, the `oscsend` (a CLI OSC message sender
+tool) comes with the `liblo` package on most distros. It is a simple CLI
+OSC sending program, and will be used throughout this document for
+examples. As oscsend does *not* accept hex values, they are noted below in
+decimal.
+
+Setting On/Off and Brightness
+-----------------------------
+Most of the buttons on the Maschine are just one colour: white.
+To turn these buttons on or off, we set the brightness.
+
+For example, to turn on or off the "group" button, the following two
+commands do just that:
+```
+oscsend localhost 42434 /maschine/button/group i 1
+oscsend localhost 42434 /maschine/button/group i 0
+```
+
+To set the brightness count "backwards" from 0x7F (decimal 127):
+```
+min:  oscsend localhost 42434 /maschine/button/group i 127
+low:  oscsend localhost 42434 /maschine/button/group i 100
+mid:  oscsend localhost 42434 /maschine/button/group i 60
+hi :  oscsend localhost 42434 /maschine/button/group i 30
+max:  oscsend localhost 42434 /maschine/button/group i 1
+```
+
+RGB buttons and Pads
+--------------------
+Group button has RGB support and uses white if just turned on. Colours are
+composed of 3 bytes: Red-Green-Blue:
+
+Translating the above (easily bit-shifted) numbers, we get this to test:
+```
+* Blue  0x0000FF
+oscsend localhost 42434 /maschine/button/group if 255       1
+
+* Green 0x00FF00
+oscsend localhost 42434 /maschine/button/group if 32768     1
+
+* Red   0xFF0000
+oscsend localhost 42434 /maschine/button/group if 8388608   1
+```
+
+Exception Buttons
+-----------------
+There are a few buttons that are only ever a specifc colour:
+* Play button *always* green
+* Rec button *always* red

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,22 @@ impl<'a> MHandler<'a> {
                 _ => return
             };
         }
+        else if msg.path.starts_with("/maschine/pad") {
+            match msg.arguments.len() {
+                3 => {
+                    if let osc::Argument::i(pad) = msg.arguments[0] {
+                      if let osc::Argument::i(color) = msg.arguments[1] {
+                          if let osc::Argument::f(brightness) = msg.arguments[2] {
+                              maschine.set_pad_light( pad as usize, (color as u32) & 0xFFFFFF, brightness as f32);
+                          }
+                      }
+                    }
+                }
+
+                _ => return
+            }
+        }
+
     }
 
     fn send_osc_msg(&self, path: &str, arguments: Vec<osc::Argument>) {


### PR DESCRIPTION
This commit adds a file that documents the basics of using the OSC
API for lighting buttons on the Maschine hardware. Examples are
provided using the LibLO "oscsend" tool.

Signed-off-by: Harry van Haaren harryhaaren@gmail.com
