### PR TITLE
maschine: midi_note_base can be set via OSC API

### DIFF
--- a/doc/osc_api.md
+++ b/doc/osc_api.md
@@ -13,6 +13,18 @@ OSC sending program, and will be used throughout this document for
 examples. As oscsend does *not* accept hex values, they are noted below in
 decimal.
 
+Setting MIDI base note
+----------------------
+Maschine.rs can be configured in what the lowest MIDI note is that is sent
+by the pads - this is useful to allow an application configure which MIDI
+notes will be sent. The default value is 48, but can be easily configured
+now.
+
+The OSC API exposes the MIDI note number as follows:
+```
+oscsend localhost 42434 /maschine/midi_note_base i 36
+```
+
 Setting On/Off and Brightness
 -----------------------------
 Most of the buttons on the Maschine are just one colour: white.

--- a/src/base/maschine.rs
+++ b/src/base/maschine.rs
@@ -59,6 +59,9 @@ pub trait Maschine {
 
     fn get_pad_pressure(&self, pad_idx: usize) -> Result<f32, ()>;
 
+    fn get_midi_note_base(&self) -> u8;
+    fn set_midi_note_base(&mut self, base: u8);
+
     fn set_pad_light(&mut self, pad_idx: usize, color: u32, brightness: f32);
     fn set_button_light(&mut self, btn: MaschineButton, color: u32, brightness: f32);
 

--- a/src/devices/mk2/mikro.rs
+++ b/src/devices/mk2/mikro.rs
@@ -87,7 +87,9 @@ pub struct Mikro {
     light_buf: [u8; 79],
 
     pads: [MaschinePad; 16],
-    buttons: [u8; 5]
+    buttons: [u8; 5],
+
+    midi_note_base: u8
 }
 
 impl Mikro {
@@ -118,7 +120,9 @@ impl Mikro {
             light_buf: [0u8; 79],
 
             pads: Mikro::sixteen_maschine_pads(),
-            buttons: [0, 0, 0, 0, 0x10]
+            buttons: [0, 0, 0, 0, 0x10],
+
+            midi_note_base: 48
         };
 
         _self.light_buf[0] = 0x80;
@@ -208,6 +212,14 @@ impl Maschine for Mikro {
         let rgb = &mut self.light_buf[offset .. (offset + 3)];
 
         set_rgb_light(rgb, color, brightness);
+    }
+
+    fn set_midi_note_base(&mut self, base: u8) {
+      self.midi_note_base = base;
+    }
+
+    fn get_midi_note_base(&self) -> u8 {
+      return self.midi_note_base;
     }
 
     fn set_button_light(&mut self, btn: MaschineButton, color: u32, brightness: f32) {


### PR DESCRIPTION
This commit introduces the concept of a MIDI base note, to allow
applications to set the lowest MIDI note that will be sent for the pads.

This is useful if an application expects a specific "octave" to be
selected, and avoids users having to manually select it.

Documentation updated, section for midi_note_base added.

Signed-off-by: Harry van Haaren harryhaaren@gmail.com
